### PR TITLE
New Spree Flash notice for 'order complete'

### DIFF
--- a/app/controllers/spree/affirm_controller.rb
+++ b/app/controllers/spree/affirm_controller.rb
@@ -64,7 +64,7 @@ module Spree
       if order.completed?
         session[:order_id] = nil
         flash.notice = Spree.t(:order_processed_successfully)
-        flash[:commerce_tracking] = "nothing special"
+        flash[:order_completed] = true
         redirect_to completion_route order
       else
         redirect_to checkout_state_path(order.state)


### PR DESCRIPTION
This changed in the new version of spree. Right now the text "nothing special" is displaying to our customers (!) in a flash message, and none of our messaging is showing up, because it's written in our code as

```
- if flash[:order_completed]
  %h1 Your order is complete!
```
