### PR TITLE
Use country code with abbr to find the Spree::State

### DIFF
--- a/app/controllers/spree/affirm_controller.rb
+++ b/app/controllers/spree/affirm_controller.rb
@@ -91,10 +91,10 @@ module Spree
 
     def generate_spree_address(affirm_address)
       # find the state and country in spree
-      _state    = Spree::State.find_by_abbr(affirm_address["address"]["region1_code"]) or
-                  Spree::State.find_by_name(affirm_address["address"]["region1_code"])
       _country  = Spree::Country.find_by_iso3(affirm_address["address"]["country_code"]) or
                   Spree::Country.find_by_iso(affirm_address["address"]["country_code"])
+      _state    = Spree::State.find_by_abbr_and_country_id(affirm_address["address"]["region1_code"], _country.id) or
+                  Spree::State.find_by_name_and_country_id(affirm_address["address"]["region1_code"], _country.id)
 
       # try to get the name from first and last
       _firstname = affirm_address["name"]["first"] if affirm_address["name"]["first"].present?


### PR DESCRIPTION
Finding Spree::State first may invalidate the payment created. Searching by abbr 'NY' first returns a state called Nyíregyháza in Hungary rather than New York. Finding by Spree::Country and using that to find the Spree::State may be better.
