### PR TITLE
Fixing refunding issue for spree 3.1+

### DIFF
--- a/app/models/spree/gateway/affirm.rb
+++ b/app/models/spree/gateway/affirm.rb
@@ -43,17 +43,8 @@ module Spree
 
       if _payment.pending?
         _payment.void_transaction!
-
       elsif _payment.completed? && _payment.can_credit?
-
-        # create adjustment
-        #_payment.order.adjustments.create(
-        #    label: "Refund - Canceled Order",
-        #    amount: -_payment.credit_allowed.to_f,
-        #    order: _payment.order
-        #)
-        #Spree::OrderUpdater.new(_payment.order).update
-        return provider.refund(_payment.credit_allowed.to_money.cents, charge_ari)
+        provider.refund(_payment.credit_allowed.to_money.cents, charge_ari)
       end
     end
   end

--- a/app/models/spree/gateway/affirm.rb
+++ b/app/models/spree/gateway/affirm.rb
@@ -47,14 +47,13 @@ module Spree
       elsif _payment.completed? && _payment.can_credit?
 
         # create adjustment
-        _payment.order.adjustments.create(
-            label: "Refund - Canceled Order",
-            amount: -_payment.credit_allowed.to_f,
-            order: _payment.order
-        )
-        Spree::OrderUpdater.new(_payment.order).update
-        provider.refund(_payment.credit_allowed.to_money.cents, charge_ari)
-      
+        #_payment.order.adjustments.create(
+        #    label: "Refund - Canceled Order",
+        #    amount: -_payment.credit_allowed.to_f,
+        #    order: _payment.order
+        #)
+        #Spree::OrderUpdater.new(_payment.order).update
+        return provider.refund(_payment.credit_allowed.to_money.cents, charge_ari)
       end
     end
   end

--- a/spec/models/spree_gateway_affirm_spec.rb
+++ b/spec/models/spree_gateway_affirm_spec.rb
@@ -75,9 +75,6 @@ describe Spree::Gateway::Affirm do
           expect(affirm_payment).to receive(:credit!).and_return false
           _payment_amount = affirm_payment.credit_allowed
           affirm_payment.payment_method.cancel affirm_payment.response_code
-
-          expect(affirm_payment.order.adjustments.count).to be > 0
-          expect(affirm_payment.order.adjustments.last.amount).to eq(-_payment_amount)
         end
       end
 


### PR DESCRIPTION
This fixes the issue with cancelling an Affirm order. The returned value from the provider should be enough and no adjustment is needed.