### PR TITLE
Take Store Credit Payments into Consideration When Submitting Affirm Payment

### DIFF
--- a/app/controllers/spree/affirm_controller.rb
+++ b/app/controllers/spree/affirm_controller.rb
@@ -54,7 +54,7 @@ module Spree
 
       _affirm_payment = order.payments.create!({
         payment_method: payment_method,
-        amount: order.total,
+        amount: order.outstanding_balance,
         source: _affirm_checkout
       })
 

--- a/app/views/spree/checkout/payment/_affirm.html.erb
+++ b/app/views/spree/checkout/payment/_affirm.html.erb
@@ -20,7 +20,7 @@
         set the shared checkout data
     \*****************************************************/
     affirm.checkout({
-      total:                <%= (@order.total * 100).to_i %>,
+      total:                <%= (@order.outstanding_balance * 100).to_i %>,
       currency:             "USD",
       tax_amount:           <%= (@order.additional_tax_total * 100).to_i %>,
       order_id:             "<%= @order.number %>",


### PR DESCRIPTION
When user selects store credit, make sure to send the remaining amount and not the entire total to Affirm.