### PR TITLE
Remove the hard lock on spree_core version

### DIFF
--- a/spree_affirm.gemspec
+++ b/spree_affirm.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'spree_core', '~> 2.2', '>= 2.2.0'
+  s.add_dependency 'spree_core', '>= 2.2.0'
 
   s.add_development_dependency 'factory_girl', '~> 4.2'
   s.add_development_dependency 'ffaker', '~> 1.16'


### PR DESCRIPTION
This will allow spree_affirm to work alongside Spree 4+ otherwise you will see bundler errors that conflict with spree_core versions.