### PR TITLE
[EC-2521] migrate charges api to transactions api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gem 'spree_auth_devise', '~> 3.3'
 gem 'spree_core', '~> 3.3'
 gem 'spree_gateway', '~> 3.3'
+gem 'rollbar'
 
 group :test do
   gem 'coffee-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source 'https://rubygems.org'
 gem 'spree_auth_devise', '~> 3.3'
 gem 'spree_core', '~> 3.3'
 gem 'spree_gateway', '~> 3.3'
-gem 'rollbar'
 
 group :test do
   gem 'coffee-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -1,19 +1,19 @@
 source 'https://rubygems.org'
 
-gem 'spree', github: 'spree/spree', branch: '2-4-stable'
-gem 'spree_gateway', github: 'spree/spree_gateway', branch: '2-4-stable'
-gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: '2-4-stable'
+gem 'spree_auth_devise', '~> 3.3'
+gem 'spree_core', '~> 3.3'
+gem 'spree_gateway', '~> 3.3'
 
 group :test do
   gem 'coffee-rails'
-  gem 'sass-rails', '~> 4.0.3'
-  gem 'money', '6.5.1'
-  gem 'rspec-rails', '~> 2.10'
-  gem 'shoulda-matchers', '2.2.0'
-  gem 'simplecov', :require => false
-  gem 'simplecov-rcov'
   gem 'database_cleaner'
   gem 'minitest'
+  gem 'money', '6.5.1'
+  gem 'rspec-rails', '~> 2.10'
+  gem 'sass-rails', '~> 4.0.3'
+  gem 'shoulda-matchers', '2.2.0'
+  gem 'simplecov', require: false
+  gem 'simplecov-rcov'
 end
 
 gemspec

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 SpreeAffirm
 ===========
 
+https://docs.affirm.com/affirm-developers/reference/introduction
+
 Installation
 ------------
 

--- a/app/controllers/spree/affirm_controller.rb
+++ b/app/controllers/spree/affirm_controller.rb
@@ -5,12 +5,10 @@ module Spree
       order = find_current_order || raise(ActiveRecord::RecordNotFound)
 
       if !params[:checkout_token]
-        flash[:notice] = "Invalid order confirmation data."
         return redirect_to checkout_state_path(current_order.state)
       end
 
       if order.complete?
-        flash[:notice] = "Order already completed."
         return redirect_to completion_route order
       end
 
@@ -58,9 +56,6 @@ module Spree
       while order.next; end
 
       if order.completed?
-        session[:order_id] = nil
-        flash.notice = Spree.t(:order_processed_successfully)
-        flash[:order_completed] = true
         redirect_to ENV['affirm_completion_url'] || completion_route(order)
       else
         redirect_to ENV['affirm_checkout_url'] || checkout_state_path(order.state)
@@ -73,6 +68,10 @@ module Spree
     end
 
     private
+
+    def checkout_state_path(state)
+      "/checkout/#{state}"
+    end
 
     def find_current_order
       current_api_user ? current_api_user.orders.incomplete.order(:created_at).last : nil
@@ -87,7 +86,7 @@ module Spree
     end
 
     def completion_route(order)
-      spree.order_path(order)
+      "/orders/#{order.number}"
     end
 
     def generate_spree_address(affirm_address)

--- a/app/controllers/spree/affirm_controller.rb
+++ b/app/controllers/spree/affirm_controller.rb
@@ -64,6 +64,7 @@ module Spree
     end
 
     def cancel
+      Rollbar.info('[spree_affirm] User canceled on Affirm', order_token: order_token)
       redirect_to checkout_path
     end
 

--- a/app/controllers/spree/affirm_controller.rb
+++ b/app/controllers/spree/affirm_controller.rb
@@ -86,7 +86,7 @@ module Spree
     end
 
     def completion_route(order)
-      "/orders/#{order.number}"
+      "/account/orders/#{order.number}"
     end
 
     def generate_spree_address(affirm_address)

--- a/app/controllers/spree/affirm_controller.rb
+++ b/app/controllers/spree/affirm_controller.rb
@@ -1,7 +1,5 @@
 module Spree
   class AffirmController < Spree::Api::BaseController
-    helper 'spree/orders'
-
     def confirm
       authorize! :create, Spree::Order
       order = find_current_order || raise(ActiveRecord::RecordNotFound)

--- a/app/controllers/spree/affirm_controller.rb
+++ b/app/controllers/spree/affirm_controller.rb
@@ -5,7 +5,7 @@ module Spree
       order = find_current_order || raise(ActiveRecord::RecordNotFound)
 
       if !params[:checkout_token]
-        return redirect_to checkout_state_path(current_order.state)
+        return redirect_to checkout_state_path(order.state)
       end
 
       if order.complete?
@@ -56,15 +56,15 @@ module Spree
       while order.next; end
 
       if order.completed?
-        redirect_to ENV['affirm_completion_url'] || completion_route(order)
+        redirect_to ENV['AFFIRM_COMPLETION_URL'] || completion_route(order)
       else
-        redirect_to ENV['affirm_checkout_url'] || checkout_state_path(order.state)
+        redirect_to ENV['AFFIRM_CHECKOUT_URL'] || checkout_state_path(order.state)
       end
     end
 
     def cancel
-      authorize! :update, @order, params[:token]
-      redirect_to checkout_state_path(current_order.state)
+      order = find_current_order || raise(ActiveRecord::RecordNotFound)
+      redirect_to checkout_state_path(order.state)
     end
 
     private

--- a/app/controllers/spree/affirm_controller.rb
+++ b/app/controllers/spree/affirm_controller.rb
@@ -59,7 +59,7 @@ module Spree
       })
 
       # transition to confirm or complete
-      order.next
+      order.next!
 
       redirect_to checkout_path
     end

--- a/app/controllers/spree/affirm_controller.rb
+++ b/app/controllers/spree/affirm_controller.rb
@@ -63,9 +63,9 @@ module Spree
         session[:order_id] = nil
         flash.notice = Spree.t(:order_processed_successfully)
         flash[:order_completed] = true
-        redirect_to completion_route order
+        redirect_to ENV['affirm_completion_url'] || completion_route(order)
       else
-        redirect_to checkout_state_path(order.state)
+        redirect_to ENV['affirm_checkout_url'] || checkout_state_path(order.state)
       end
     end
 

--- a/app/controllers/spree/affirm_controller.rb
+++ b/app/controllers/spree/affirm_controller.rb
@@ -5,12 +5,12 @@ module Spree
       authorize! :update, order, order_token
 
       if !params[:checkout_token]
-        Rollbar.warn('[spree_affirm] Invalid order confirmation data', order_token: order_token)
+        logger.warn('[spree_affirm] Invalid order confirmation data. Token: #{order_token}')
         return redirect_to checkout_path
       end
 
       if !order.payment?
-        Rollbar.warn('[spree_affirm] Order was not in the payment state', order_token: order_token)
+        logger.warn('[spree_affirm] Order was not in the payment state. Token: #{order_token}')
         return redirect_to checkout_path
       end
 
@@ -22,10 +22,10 @@ module Spree
 
       # check if data needs to be updated
       unless _affirm_checkout.valid?
-        Rollbar.error('[spree_affirm] Affirm error: Invalid checkout')
+        logger.error('[spree_affirm] Affirm error: Invalid checkout')
 
         _affirm_checkout.errors.each do |field, error|
-          Rollbar.error('[spree_affirm] Affirm error', field: field, error: error)
+          logger.error('[spree_affirm] Affirm error in field #{field}: #{error}')
           case field
           when :billing_address
             # FIXME(brian): pass the phone number to the |order| in a better place
@@ -47,7 +47,7 @@ module Spree
 
         order.save
       else
-        Rollbar.info('[spree_affirm] Valid checkout', order_token: order_token)
+        logger.info('[spree_affirm] Valid checkout. Token: #{order_token}')
       end
 
       _affirm_checkout.save
@@ -65,7 +65,7 @@ module Spree
     end
 
     def cancel
-      Rollbar.info('[spree_affirm] User canceled on Affirm', order_token: order_token)
+      logger.info('[spree_affirm] User canceled on Affirm. Token: #{order_token}')
       redirect_to checkout_path
     end
 

--- a/app/controllers/spree/affirm_controller.rb
+++ b/app/controllers/spree/affirm_controller.rb
@@ -4,7 +4,7 @@ module Spree
       order = find_current_order || raise(ActiveRecord::RecordNotFound)
       authorize! :update, order, order_token
 
-      if !params[:checkout_token]
+      if !params[:transaction_id]
         ::Rails.logger.warn('[spree_affirm] Invalid order confirmation data. Token: #{order_token}')
         return redirect_to checkout_path
       end
@@ -16,7 +16,7 @@ module Spree
 
       _affirm_checkout = Spree::AffirmCheckout.new(
         order: order,
-        token: params[:checkout_token],
+        token: params[:transaction_id],
         payment_method: payment_method
       )
 

--- a/app/controllers/spree/affirm_controller.rb
+++ b/app/controllers/spree/affirm_controller.rb
@@ -86,7 +86,7 @@ module Spree
     end
 
     def completion_route(order)
-      "/account/orders/#{order.number}"
+      '/checkout/complete'
     end
 
     def generate_spree_address(affirm_address)

--- a/app/controllers/spree/affirm_controller.rb
+++ b/app/controllers/spree/affirm_controller.rb
@@ -59,7 +59,7 @@ module Spree
       })
 
       # transition to confirm or complete
-      while order.next; end
+      order.next
 
       redirect_to checkout_path
     end

--- a/app/controllers/spree/affirm_controller.rb
+++ b/app/controllers/spree/affirm_controller.rb
@@ -4,7 +4,8 @@ module Spree
       order = find_current_order || raise(ActiveRecord::RecordNotFound)
       authorize! :update, order, order_token
 
-      if !params[:checkout_token] || order.complete?
+      # TODO Membership check is specific to our implementation
+      if !params[:checkout_token] || order.membership? || order.complete?
         return redirect_to checkout_path
       end
 

--- a/app/controllers/spree/affirm_controller.rb
+++ b/app/controllers/spree/affirm_controller.rb
@@ -4,8 +4,7 @@ module Spree
       order = find_current_order || raise(ActiveRecord::RecordNotFound)
       authorize! :update, order, order_token
 
-      # TODO Membership check is specific to our implementation
-      if !params[:checkout_token] || order.membership? || order.complete?
+      if !params[:checkout_token] || !order.payment?
         return redirect_to checkout_path
       end
 

--- a/app/controllers/spree/affirm_controller.rb
+++ b/app/controllers/spree/affirm_controller.rb
@@ -36,7 +36,7 @@ module Spree
             order.ship_address.phone = phone
 
           when :billing_email
-            order.email = _affirm_checkout.details["billing"]["email"]
+            order.email = _affirm_checkout.details['billing']['email']
 
           end
         end

--- a/app/controllers/spree/affirm_controller.rb
+++ b/app/controllers/spree/affirm_controller.rb
@@ -5,12 +5,12 @@ module Spree
       authorize! :update, order, order_token
 
       if !params[:checkout_token]
-        logger.warn('[spree_affirm] Invalid order confirmation data. Token: #{order_token}')
+        ::Rails.logger.warn('[spree_affirm] Invalid order confirmation data. Token: #{order_token}')
         return redirect_to checkout_path
       end
 
       if !order.payment?
-        logger.warn('[spree_affirm] Order was not in the payment state. Token: #{order_token}')
+        ::Rails.logger.warn('[spree_affirm] Order was not in the payment state. Token: #{order_token}')
         return redirect_to checkout_path
       end
 
@@ -22,10 +22,10 @@ module Spree
 
       # check if data needs to be updated
       unless _affirm_checkout.valid?
-        logger.error('[spree_affirm] Affirm error: Invalid checkout')
+        ::Rails.logger.error('[spree_affirm] Affirm error: Invalid checkout')
 
         _affirm_checkout.errors.each do |field, error|
-          logger.error('[spree_affirm] Affirm error in field #{field}: #{error}')
+          ::Rails.logger.error('[spree_affirm] Affirm error in field #{field}: #{error}')
           case field
           when :billing_address
             # FIXME(brian): pass the phone number to the |order| in a better place
@@ -47,7 +47,7 @@ module Spree
 
         order.save
       else
-        logger.info('[spree_affirm] Valid checkout. Token: #{order_token}')
+        ::Rails.logger.info('[spree_affirm] Valid checkout. Token: #{order_token}')
       end
 
       _affirm_checkout.save
@@ -65,7 +65,7 @@ module Spree
     end
 
     def cancel
-      logger.info('[spree_affirm] User canceled on Affirm. Token: #{order_token}')
+      ::Rails.logger.info('[spree_affirm] User canceled on Affirm. Token: #{order_token}')
       redirect_to checkout_path
     end
 

--- a/app/controllers/spree/affirm_controller.rb
+++ b/app/controllers/spree/affirm_controller.rb
@@ -22,6 +22,7 @@ module Spree
 
       # check if data needs to be updated
       unless _affirm_checkout.valid?
+        Rollbar.error('[spree_affirm] Affirm error: Invalid checkout')
 
         _affirm_checkout.errors.each do |field, error|
           Rollbar.error('[spree_affirm] Affirm error', field: field, error: error)

--- a/app/models/spree/affirm_checkout.rb
+++ b/app/models/spree/affirm_checkout.rb
@@ -22,7 +22,6 @@ module Spree
       check_matching_shipping_address
       check_matching_billing_address
       check_matching_billing_email
-      check_matching_product_key
     end
 
     def check_valid_products
@@ -71,12 +70,6 @@ module Spree
     def check_matching_billing_email
       if details["billing"]["email"].present? and details["billing"]["email"].casecmp(order.email) != 0
         errors.add :billing_email, "Billing email mismatch"
-      end
-    end
-
-    def check_matching_product_key
-      if details["config"]["financial_product_key"] != payment_method.preferred_product_key
-        errors.add :financial_product_key, "Product key mismatch"
       end
     end
 

--- a/app/models/spree/affirm_checkout.rb
+++ b/app/models/spree/affirm_checkout.rb
@@ -25,7 +25,6 @@ module Spree
     end
 
     def check_valid_products
-      Rails.logger.info "[AFFIRM] #check_valid_products. details: #{details['items'].inspect}, order: #{order.line_items.inspect}"
       # ensure the number of line items matches
       if details["items"].size != order.line_items.size
         errors.add :line_items, "Order size mismatch"

--- a/app/models/spree/affirm_checkout.rb
+++ b/app/models/spree/affirm_checkout.rb
@@ -83,6 +83,7 @@ module Spree
     end
 
     # Indicates whether its possible to void the payment.
+    # NOTE: Currently not possible to void captured payments through the API
     def can_void?(payment)
       !payment.void? && payment.pending? && !payment.response_code.blank?
     end
@@ -91,12 +92,10 @@ module Spree
     # payment be settled first which generally happens within 12-24 hours of the transaction.
     def can_credit?(payment)
       return false unless payment.completed?
-      return false unless payment.order.payment_state == 'credit_owed'
       payment.credit_allowed > 0
     end
 
     private
-
 
     def normalize_affirm_address(affirm_address_details)
       Affirm::AddressValidator.normalize_affirm_address(affirm_address_details)

--- a/app/models/spree/affirm_checkout.rb
+++ b/app/models/spree/affirm_checkout.rb
@@ -25,6 +25,7 @@ module Spree
     end
 
     def check_valid_products
+      Rails.logger.info "[AFFIRM] #check_valid_products. details: #{details['items'].inspect}, order: #{order.line_items.inspect}"
       # ensure the number of line items matches
       if details["items"].size != order.line_items.size
         errors.add :line_items, "Order size mismatch"

--- a/app/models/spree/affirm_checkout.rb
+++ b/app/models/spree/affirm_checkout.rb
@@ -108,8 +108,9 @@ module Spree
         city:         spree_address.city,
         street1:      spree_address.address1,
         street2:      spree_address.address2,
-        postal_code:  spree_address.zipcode,
         region1_code: spree_address.state.abbr
+        # XXX: Do not check zipcode
+        # Affirm does not work with zip+4 values, but we require them
 
       # check that each value from affirm matches the spree address
       }.each do |affirm_key, spree_val|

--- a/app/models/spree/affirm_transaction.rb
+++ b/app/models/spree/affirm_transaction.rb
@@ -1,0 +1,6 @@
+module Spree
+  # this is a hack to patch over the parts of Spree Affirm Checkouts that we
+  # now need to point to Affirms Transaction API
+  class AffirmTransaction < Spree::AffirmCheckout
+  end
+end

--- a/app/models/spree/gateway/affirm.rb
+++ b/app/models/spree/gateway/affirm.rb
@@ -36,7 +36,7 @@ module Spree
     def cancel(charge_ari)
       _payment = Spree::Payment.valid.where(
         response_code: charge_ari,
-        source_type:   "#{payment_source_class}"
+        source_type:   payment_source_class.to_s
       ).first
 
       return if _payment.nil?
@@ -44,15 +44,15 @@ module Spree
       if _payment.pending?
         _payment.void_transaction!
 
-      elsif _payment.completed? and _payment.can_credit?
+      elsif _payment.completed? && _payment.can_credit?
 
         # create adjustment
         _payment.order.adjustments.create(
-            label: "Refund - Canceled Order",
-            amount: -_payment.credit_allowed.to_f,
-            order: _payment.order
+          label: 'Refund - Canceled Order',
+          amount: -_payment.credit_allowed.to_f,
+          order: _payment.order
         )
-        _payment.order.update!
+        _payment.order.update!({})
 
         _payment.credit!
 

--- a/app/models/spree/gateway/affirm.rb
+++ b/app/models/spree/gateway/affirm.rb
@@ -3,7 +3,6 @@ module Spree
     preference :api_key, :string
     preference :secret_key, :string
     preference :server, :string, default: 'www.affirm.com'
-    preference :term, :number, default: 12
     preference :product_key, :string
 
     def provider_class

--- a/app/models/spree/gateway/affirm.rb
+++ b/app/models/spree/gateway/affirm.rb
@@ -52,10 +52,9 @@ module Spree
           amount: -_payment.credit_allowed.to_f,
           order: _payment.order
         )
-        _payment.order.update!({})
+        Spree::OrderUpdater.new(_payment.order).update
 
-        _payment.credit!
-
+        provider.refund(_payment.credit_allowed.to_money.cents, charge_ari)
       end
     end
   end

--- a/app/models/spree/gateway/affirm.rb
+++ b/app/models/spree/gateway/affirm.rb
@@ -3,6 +3,7 @@ module Spree
     preference :api_key, :string
     preference :secret_key, :string
     preference :server, :string, default: 'www.affirm.com'
+    preference :term, :number, default: 12
     preference :product_key, :string
 
     def provider_class

--- a/config/logger.rb
+++ b/config/logger.rb
@@ -1,0 +1,2 @@
+logger = Logger.new(STDOUT)
+logger.log_level = :info

--- a/config/logger.rb
+++ b/config/logger.rb
@@ -1,2 +1,0 @@
-logger = Logger.new(STDOUT)
-logger.log_level = :info

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Spree::Core::Engine.routes.draw do
   # Add your extension routes here
-  post '/affirm/confirm', :to => "affirm#confirm", :as => :confirm_affirm
-  get '/affirm/cancel', :to => "affirm#cancel", :as => :cancel_affirm
+  post '/affirm/confirm', to: "affirm#confirm", as: :confirm_affirm
+  get '/affirm/cancel', to: "affirm#cancel", as: :cancel_affirm
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Spree::Core::Engine.routes.draw do
   # Add your extension routes here
-  post '/affirm/confirm', to: "affirm#confirm", as: :confirm_affirm
-  get '/affirm/cancel', to: "affirm#cancel", as: :cancel_affirm
+  post '/affirm/confirm', to: 'affirm#confirm', as: :confirm_affirm
+  get '/affirm/cancel', to: 'affirm#cancel', as: :cancel_affirm
 end

--- a/lib/active_merchant/billing/affirm.rb
+++ b/lib/active_merchant/billing/affirm.rb
@@ -20,16 +20,16 @@ module ActiveMerchant #:nodoc:
         result = commit(:post, "", {"checkout_token"=>affirm_source.token}, options, true)
         return result unless result.success?
 
-        logger.info("[Affirm] amount(money).to_i: #{amount(money).to_i}, result.params[\"amount\"].to_i: #{result.params["amount"].to_i}")
+        ::Rails.logger.info("[Affirm] amount(money).to_i: #{amount(money).to_i}, result.params[\"amount\"].to_i: #{result.params["amount"].to_i}")
 
         if amount(money).to_i != result.params["amount"].to_i
-          logger.error('[spree_affirm] Auth amount does not match charge amount')
+          ::Rails.logger.error('[spree_affirm] Auth amount does not match charge amount')
           return Response.new(false,
                               "Auth amount does not match charge amount",
                               result.params
                              )
         elsif result.params["pending"].to_s != "true"
-          logger.error('[spree_affirm] Error authorizing charge')
+          ::Rails.logger.error('[spree_affirm] Error authorizing charge')
           return Response.new(false,
                               "There was an error authorizing this Charge",
                               result.params
@@ -58,7 +58,7 @@ module ActiveMerchant #:nodoc:
         return result unless result.success?
 
         if amount(money).to_i != result.params["amount"].to_i
-          logger.error('[spree_affirm] Capture amount does not match charge amount')
+          ::Rails.logger.error('[spree_affirm] Capture amount does not match charge amount')
           return Response.new(false,
                 "Capture amount does not match charge amount",
                 result.params

--- a/lib/active_merchant/billing/affirm.rb
+++ b/lib/active_merchant/billing/affirm.rb
@@ -23,11 +23,13 @@ module ActiveMerchant #:nodoc:
         ::Rails.logger.info("[Affirm] amount(money).to_i: #{amount(money).to_i}, result.params[\"amount\"].to_i: #{result.params["amount"].to_i}")
 
         if amount(money).to_i != result.params["amount"].to_i
+          Rollbar.error('[spree_affirm] Auth amount does not match charge amount')
           return Response.new(false,
                               "Auth amount does not match charge amount",
                               result.params
                              )
         elsif result.params["pending"].to_s != "true"
+          Rollbar.error('[spree_affirm] Error authorizing charge')
           return Response.new(false,
                               "There was an error authorizing this Charge",
                               result.params
@@ -56,6 +58,7 @@ module ActiveMerchant #:nodoc:
         return result unless result.success?
 
         if amount(money).to_i != result.params["amount"].to_i
+          Rollbar.error('[spree_affirm] Capture amount does not match charge amount')
           return Response.new(false,
                 "Capture amount does not match charge amount",
                 result.params

--- a/lib/active_merchant/billing/affirm.rb
+++ b/lib/active_merchant/billing/affirm.rb
@@ -20,16 +20,16 @@ module ActiveMerchant #:nodoc:
         result = commit(:post, "", {"checkout_token"=>affirm_source.token}, options, true)
         return result unless result.success?
 
-        ::Rails.logger.info("[Affirm] amount(money).to_i: #{amount(money).to_i}, result.params[\"amount\"].to_i: #{result.params["amount"].to_i}")
+        logger.info("[Affirm] amount(money).to_i: #{amount(money).to_i}, result.params[\"amount\"].to_i: #{result.params["amount"].to_i}")
 
         if amount(money).to_i != result.params["amount"].to_i
-          Rollbar.error('[spree_affirm] Auth amount does not match charge amount')
+          logger.error('[spree_affirm] Auth amount does not match charge amount')
           return Response.new(false,
                               "Auth amount does not match charge amount",
                               result.params
                              )
         elsif result.params["pending"].to_s != "true"
-          Rollbar.error('[spree_affirm] Error authorizing charge')
+          logger.error('[spree_affirm] Error authorizing charge')
           return Response.new(false,
                               "There was an error authorizing this Charge",
                               result.params
@@ -58,7 +58,7 @@ module ActiveMerchant #:nodoc:
         return result unless result.success?
 
         if amount(money).to_i != result.params["amount"].to_i
-          Rollbar.error('[spree_affirm] Capture amount does not match charge amount')
+          logger.error('[spree_affirm] Capture amount does not match charge amount')
           return Response.new(false,
                 "Capture amount does not match charge amount",
                 result.params

--- a/lib/active_merchant/billing/affirm.rb
+++ b/lib/active_merchant/billing/affirm.rb
@@ -20,6 +20,8 @@ module ActiveMerchant #:nodoc:
         result = commit(:post, "", {"checkout_token"=>affirm_source.token}, options, true)
         return result unless result.success?
 
+        ::Rails.logger.info("[Affirm] amount(money).to_i: #{amount(money).to_i}, result.params[\"amount\"].to_i: #{result.params["amount"].to_i}")
+
         if amount(money).to_i != result.params["amount"].to_i
           return Response.new(false,
                               "Auth amount does not match charge amount",

--- a/lib/spree_affirm/engine.rb
+++ b/lib/spree_affirm/engine.rb
@@ -25,3 +25,5 @@ module SpreeAffirm
     end
   end
 end
+
+require 'active_merchant/billing/affirm'

--- a/spec/controllers/affirm_controller_spec.rb
+++ b/spec/controllers/affirm_controller_spec.rb
@@ -11,7 +11,8 @@ describe Spree::AffirmController do
   describe "POST confirm" do
 
     def post_request(token, payment_id)
-      post :confirm, checkout_token: token, payment_method_id: payment_id, use_route: 'spree'
+      # [wipn] check this against the solidus gems to see what sort of arguments are being sent to this local callback controller
+      post :confirm, transaction_id: token, payment_method_id: payment_id, use_route: 'spree'
     end
 
     before do
@@ -25,7 +26,7 @@ describe Spree::AffirmController do
         controller.stub current_order: checkout.order
       end
 
-      context "when no checkout_token is provided" do
+      context "when no transaction_id is provided" do
         it "redirects to the current order state" do
           post_request(nil, nil)
           expect(response).to redirect_to(controller.checkout_state_path(checkout.order.state))

--- a/spec/lib/active_merchant/billing/affirm_spec.rb
+++ b/spec/lib/active_merchant/billing/affirm_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 
 describe ActiveMerchant::Billing::Affirm do
   let(:affirm_payment) { FactoryGirl.create(:affirm_payment) }
-  let(:charge_id) { "1234-5678-9012" }
+  let(:transaction_id) { "1234-5678-9012" }
 
 
   def expect_request(method, url_regexp, data, successful_response=true, response={})
@@ -20,7 +20,7 @@ describe ActiveMerchant::Billing::Affirm do
 
       # create response
       _response = (response || {}).reverse_merge({
-        id: charge_id,
+        id: transaction_id,
         pending: true,
         amount: 8000
       })
@@ -64,8 +64,8 @@ describe ActiveMerchant::Billing::Affirm do
 
 
   describe "#authorize" do
-    it "sends a POST to /api/v2/charges/ with the checkout_token" do
-      expect_post_and_return_success(/\/api\/v2\/charges/, {checkout_token: affirm_payment.source.token}, {amount: 8000})
+    it "sends a POST to /api/v2/transactions/ with the transaction_id" do
+      expect_post_and_return_success(/\/api\/v2\/transactions/, {transaction_id: affirm_payment.source.token}, {amount: 8000})
       affirm_payment.payment_method.provider.authorize(8000, affirm_payment.source)
     end
 
@@ -83,7 +83,7 @@ describe ActiveMerchant::Billing::Affirm do
     context "when the POST respone is successful" do
       context "when the auth amount does not match the given amount" do
         it "returns an error response for that error" do
-          expect_post_and_return_success(/\/api\/v2\/charges/, {checkout_token: affirm_payment.source.token}, {amount: 9000})
+          expect_post_and_return_success(/\/api\/v2\/transactions/, {transaction_id: affirm_payment.source.token}, {amount: 9000})
           result = affirm_payment.payment_method.provider.authorize(1999, affirm_payment.source)
           expect(result.success?).to be(false)
           expect(result.message).to eq("Auth amount does not match charge amount")
@@ -93,7 +93,7 @@ describe ActiveMerchant::Billing::Affirm do
 
       context "when the charge is not pending in the response" do
         it "returns an error response for that error" do
-          expect_post_and_return_success(/\/api\/v2\/charges/, {checkout_token: affirm_payment.source.token}, {amount: 9000, pending: false})
+          expect_post_and_return_success(/\/api\/v2\/transactions/, {transaction_id: affirm_payment.source.token}, {amount: 9000, pending: false})
           result = affirm_payment.payment_method.provider.authorize(9000, affirm_payment.source)
           expect(result.success?).to be(false)
           expect(result.message).to eq("There was an error authorizing this Charge")
@@ -102,7 +102,7 @@ describe ActiveMerchant::Billing::Affirm do
 
 
       it "returns the result from the POST" do
-        expect_post_and_return_success(/\/api\/v2\/charges/, {checkout_token: affirm_payment.source.token}, {amount: 9000})
+        expect_post_and_return_success(/\/api\/v2\/transactions/, {transaction_id: affirm_payment.source.token}, {amount: 9000})
         result = affirm_payment.payment_method.provider.authorize(9000, affirm_payment.source)
         expect(result.success?).to be(true)
         expect(result.params['amount']).to eq(9000)
@@ -114,14 +114,14 @@ describe ActiveMerchant::Billing::Affirm do
 
   describe "#purchase" do
     it "authorizes the charge" do
-      expect_post_and_return_failure(/\/api\/v2\/charges/, {checkout_token: affirm_payment.source.token})
+      expect_post_and_return_failure(/\/api\/v2\/transactions/, {transaction_id: affirm_payment.source.token})
       affirm_payment.payment_method.provider.purchase(8000, affirm_payment.source)
     end
 
 
     context "when the authorize response is not successful" do
       it "returns the response of the auth response" do
-        expect_post_and_return_failure(/\/api\/v2\/charges/, {checkout_token: affirm_payment.source.token})
+        expect_post_and_return_failure(/\/api\/v2\/transactions/, {transaction_id: affirm_payment.source.token})
         purchase_result = affirm_payment.payment_method.provider.purchase(8000, affirm_payment.source)
         auth_result     = affirm_payment.payment_method.provider.authorize(8000, affirm_payment.source)
 
@@ -132,7 +132,7 @@ describe ActiveMerchant::Billing::Affirm do
 
 
       it "does not attempt to capture the charge" do
-        expect_post_and_return_failure(/\/api\/v2\/charges/, {checkout_token: affirm_payment.source.token})
+        expect_post_and_return_failure(/\/api\/v2\/transactions/, {transaction_id: affirm_payment.source.token})
         affirm_payment.payment_method.provider.should_not_receive(:capture)
         affirm_payment.payment_method.provider.purchase(8000, affirm_payment.source)
       end
@@ -141,7 +141,7 @@ describe ActiveMerchant::Billing::Affirm do
 
     context "when the authorize response is successful" do
       it "captures the charge" do
-        expect_post_and_return_success(/\/api\/v2\/charges/, {checkout_token: affirm_payment.source.token})
+        expect_post_and_return_success(/\/api\/v2\/transactions/, {transaction_id: affirm_payment.source.token})
         affirm_payment.payment_method.provider.should_receive(:capture)
         affirm_payment.payment_method.provider.purchase(8000, affirm_payment.source)
       end
@@ -152,17 +152,17 @@ describe ActiveMerchant::Billing::Affirm do
 
 
   describe "#capture" do
-    it "calls a POST to charges/[charge_ari]/capture" do
-      expect_post_and_return_success(/\/api\/v2\/charges\/#{charge_id}\/capture/, {amount: "8000"})
-      affirm_payment.payment_method.provider.capture(8000, charge_id)
+    it "calls a POST to transactions/[charge_ari]/capture" do
+      expect_post_and_return_success(/\/api\/v2\/transactions\/#{transaction_id}\/capture/, {amount: "8000"})
+      affirm_payment.payment_method.provider.capture(8000, transaction_id)
     end
 
     context "when the capture response is not successful" do
       it "returns the response" do
-        expect_post_and_return_failure(/\/api\/v2\/charges\/#{charge_id}\/capture/, {amount: "8000"},
+        expect_post_and_return_failure(/\/api\/v2\/transactions\/#{transaction_id}\/capture/, {amount: "8000"},
           message: "buuuuuusted"
         )
-        result = affirm_payment.payment_method.provider.capture(8000, charge_id)
+        result = affirm_payment.payment_method.provider.capture(8000, transaction_id)
         expect(result.success?).to be(false)
         expect(result.message).to eq("buuuuuusted")
       end
@@ -171,10 +171,10 @@ describe ActiveMerchant::Billing::Affirm do
 
     context "when the capture response is successful" do
       it "returns the response" do
-        expect_post_and_return_success(/\/api\/v2\/charges\/#{charge_id}\/capture/, {amount: "8000"},
+        expect_post_and_return_success(/\/api\/v2\/transactions\/#{transaction_id}\/capture/, {amount: "8000"},
           amount: 8000
         )
-        result = affirm_payment.payment_method.provider.capture(8000, charge_id)
+        result = affirm_payment.payment_method.provider.capture(8000, transaction_id)
         expect(result.success?).to be(true)
         expect(result.params['amount']).to eq(8000)
       end
@@ -182,10 +182,10 @@ describe ActiveMerchant::Billing::Affirm do
 
       context "when the captured amount does not equal the requested amount" do
         it "returns a failed response" do
-          expect_post_and_return_success(/\/api\/v2\/charges\/#{charge_id}\/capture/, {amount: "8000"},
+          expect_post_and_return_success(/\/api\/v2\/transactions\/#{transaction_id}\/capture/, {amount: "8000"},
             amount: 299
           )
-          result = affirm_payment.payment_method.provider.capture(8000, charge_id)
+          result = affirm_payment.payment_method.provider.capture(8000, transaction_id)
           expect(result.success?).to be(false)
           expect(result.message).to eq("Capture amount does not match charge amount")
         end
@@ -196,15 +196,15 @@ describe ActiveMerchant::Billing::Affirm do
 
 
   describe "#void" do
-    it "calls POST on /charges/[charge_ari]/void" do
-      expect_post_and_return_success(/\/api\/v2\/charges\/#{charge_id}\/void/)
-      affirm_payment.payment_method.provider.void(charge_id)
+    it "calls POST on /transactions/[charge_ari]/void" do
+      expect_post_and_return_success(/\/api\/v2\/transactions\/#{transaction_id}\/void/)
+      affirm_payment.payment_method.provider.void(transaction_id)
     end
 
 
     it "returns the response from the POST request" do
-      expect_post_and_return_success(/\/api\/v2\/charges\/#{charge_id}\/void/)
-      result = affirm_payment.payment_method.provider.void(charge_id)
+      expect_post_and_return_success(/\/api\/v2\/transactions\/#{transaction_id}\/void/)
+      result = affirm_payment.payment_method.provider.void(transaction_id)
       expect(result.success?).to be(true)
       expect(result.message).to eq("Transaction approved")
     end
@@ -213,15 +213,15 @@ describe ActiveMerchant::Billing::Affirm do
 
 
   describe "#refund" do
-    it "calls POST on /charges/[charge_ari]/refund" do
-      expect_post_and_return_success(/\/api\/v2\/charges\/#{charge_id}\/refund/, {amount: "8000"})
-      affirm_payment.payment_method.provider.refund(8000, charge_id)
+    it "calls POST on /transactions/[charge_ari]/refund" do
+      expect_post_and_return_success(/\/api\/v2\/transactions\/#{transaction_id}\/refund/, {amount: "8000"})
+      affirm_payment.payment_method.provider.refund(8000, transaction_id)
     end
 
 
     it "returns the response from the POST request" do
-      expect_post_and_return_success(/\/api\/v2\/charges\/#{charge_id}\/refund/, {amount: "8000"})
-      result = affirm_payment.payment_method.provider.refund(8000, charge_id)
+      expect_post_and_return_success(/\/api\/v2\/transactions\/#{transaction_id}\/refund/, {amount: "8000"})
+      result = affirm_payment.payment_method.provider.refund(8000, transaction_id)
       expect(result.success?).to be(true)
       expect(result.message).to eq("Transaction approved")
     end
@@ -232,15 +232,15 @@ describe ActiveMerchant::Billing::Affirm do
   describe "#credit" do
     context "when the requested amount is non zero" do
       it "calls refund with the requested amount" do
-        affirm_payment.payment_method.provider.should_receive(:refund).with(8000, charge_id, {})
-        affirm_payment.payment_method.provider.credit(8000, charge_id)
+        affirm_payment.payment_method.provider.should_receive(:refund).with(8000, transaction_id, {})
+        affirm_payment.payment_method.provider.credit(8000, transaction_id)
       end
     end
 
     context "when the requested amount is zero" do
       it "returns a valid response and does not call refund()" do
         affirm_payment.payment_method.provider.should_not_receive(:refund)
-        result = affirm_payment.payment_method.provider.credit(0, charge_id)
+        result = affirm_payment.payment_method.provider.credit(0, transaction_id)
         expect(result.success?).to be(true)
       end
     end


### PR DESCRIPTION
## What
- migrate from `/charges` API to `/transactions` API

## Why
- `/charges` is deprecated.  To roll out in CA we need to support the `/transactions` API

## Testing
- ensure affirm checkout flow still works